### PR TITLE
feat: raise notifications from turn and currency services

### DIFF
--- a/Core/CurrencyBank.cs
+++ b/Core/CurrencyBank.cs
@@ -104,7 +104,18 @@ namespace TableCore.Core
         /// </summary>
         public void Reset()
         {
+            if (_balances.Count == 0)
+            {
+                return;
+            }
+
+            var affectedPlayers = new List<Guid>(_balances.Keys);
             _balances.Clear();
+
+            foreach (var playerId in affectedPlayers)
+            {
+                BalanceChanged?.Invoke(playerId, 0);
+            }
         }
 
         private void EnsureAccountExists(Guid playerId)

--- a/Core/CurrencyBank.cs.uid
+++ b/Core/CurrencyBank.cs.uid
@@ -1,0 +1,1 @@
+uid://cempgxw1i6waf

--- a/Core/DiceService.cs.uid
+++ b/Core/DiceService.cs.uid
@@ -1,0 +1,1 @@
+uid://d3naqn25jcof0

--- a/Core/TurnManager.cs
+++ b/Core/TurnManager.cs
@@ -12,6 +12,11 @@ namespace TableCore.Core
         private int _currentIndex;
 
         /// <summary>
+        /// Raised whenever the active player changes. Emits <see cref="Guid.Empty"/> when no player is active.
+        /// </summary>
+        public event Action<Guid>? TurnChanged;
+
+        /// <summary>
         /// Gets the identifier of the player whose turn is currently active.
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown when the turn order has not been configured.</exception>
@@ -77,6 +82,8 @@ namespace TableCore.Core
             _turnOrder.Clear();
             _turnOrder.AddRange(distinctOrder);
             _currentIndex = startIndex;
+
+            TurnChanged?.Invoke(_turnOrder[_currentIndex]);
         }
 
         /// <summary>
@@ -92,7 +99,9 @@ namespace TableCore.Core
             }
 
             _currentIndex = (_currentIndex + 1) % _turnOrder.Count;
-            return _turnOrder[_currentIndex];
+            var currentPlayer = _turnOrder[_currentIndex];
+            TurnChanged?.Invoke(currentPlayer);
+            return currentPlayer;
         }
 
         /// <summary>
@@ -114,6 +123,7 @@ namespace TableCore.Core
             }
 
             _currentIndex = index;
+            TurnChanged?.Invoke(_turnOrder[_currentIndex]);
             return true;
         }
 
@@ -122,8 +132,14 @@ namespace TableCore.Core
         /// </summary>
         public void Reset()
         {
+            var hadPlayers = _turnOrder.Count > 0;
             _turnOrder.Clear();
             _currentIndex = 0;
+
+            if (hadPlayers)
+            {
+                TurnChanged?.Invoke(Guid.Empty);
+            }
         }
     }
 }

--- a/Core/TurnManager.cs.uid
+++ b/Core/TurnManager.cs.uid
@@ -1,0 +1,1 @@
+uid://bqavfl0ljm3st

--- a/Tests/Core/CurrencyBankTests.cs
+++ b/Tests/Core/CurrencyBankTests.cs
@@ -112,5 +112,27 @@ namespace TableCore.Tests.Core
 
             Assert.That(bank.GetBalance(Guid.NewGuid()), Is.EqualTo(0));
         }
+
+        [Test]
+        public void Reset_NotifiesObserversWithZeroBalances()
+        {
+            var bank = new CurrencyBank();
+            var playerA = Guid.NewGuid();
+            var playerB = Guid.NewGuid();
+            var observedEvents = new List<(Guid Player, int Balance)>();
+            bank.BalanceChanged += (id, balance) => observedEvents.Add((id, balance));
+
+            bank.SetBalance(playerA, 120);
+            bank.SetBalance(playerB, 80);
+            observedEvents.Clear();
+
+            bank.Reset();
+
+            Assert.That(observedEvents, Is.EquivalentTo(new List<(Guid, int)>
+            {
+                (playerA, 0),
+                (playerB, 0)
+            }));
+        }
     }
 }

--- a/Tests/Core/CurrencyBankTests.cs.uid
+++ b/Tests/Core/CurrencyBankTests.cs.uid
@@ -1,0 +1,1 @@
+uid://djgckmtfgc74a

--- a/Tests/Core/DiceServiceTests.cs.uid
+++ b/Tests/Core/DiceServiceTests.cs.uid
@@ -1,0 +1,1 @@
+uid://cb34qtaya5kvo

--- a/Tests/Core/TurnManagerTests.cs
+++ b/Tests/Core/TurnManagerTests.cs
@@ -86,5 +86,54 @@ namespace TableCore.Tests.Core
             Assert.That(() => manager.SetOrder(Array.Empty<Guid>()), Throws.ArgumentException);
             Assert.That(() => manager.SetOrder(new[] { Guid.NewGuid() }, startIndex: 5), Throws.TypeOf<ArgumentOutOfRangeException>());
         }
+
+        [Test]
+        public void SetOrder_RaisesTurnChangedEventForActivePlayer()
+        {
+            var manager = new TurnManager();
+            var playerA = Guid.NewGuid();
+            var playerB = Guid.NewGuid();
+            var observed = new List<Guid>();
+            manager.TurnChanged += observed.Add;
+
+            manager.SetOrder(new[] { playerA, playerB }, startIndex: 1);
+
+            Assert.That(observed, Is.EqualTo(new List<Guid> { playerB }));
+        }
+
+        [Test]
+        public void AdvanceTurn_RaisesTurnChangedEvent()
+        {
+            var manager = new TurnManager();
+            var playerA = Guid.NewGuid();
+            var playerB = Guid.NewGuid();
+            var playerC = Guid.NewGuid();
+            var observed = new List<Guid>();
+            manager.TurnChanged += observed.Add;
+
+            manager.SetOrder(new[] { playerA, playerB, playerC });
+            observed.Clear();
+
+            manager.AdvanceTurn();
+            manager.AdvanceTurn();
+
+            Assert.That(observed, Is.EqualTo(new List<Guid> { playerB, playerC }));
+        }
+
+        [Test]
+        public void Reset_RaisesTurnChangedWithEmptyGuid()
+        {
+            var manager = new TurnManager();
+            var player = Guid.NewGuid();
+            var observed = new List<Guid>();
+            manager.TurnChanged += observed.Add;
+
+            manager.SetOrder(new[] { player });
+            observed.Clear();
+
+            manager.Reset();
+
+            Assert.That(observed, Is.EqualTo(new List<Guid> { Guid.Empty }));
+        }
     }
 }

--- a/Tests/Core/TurnManagerTests.cs.uid
+++ b/Tests/Core/TurnManagerTests.cs.uid
@@ -1,0 +1,1 @@
+uid://clplx6iffe88k


### PR DESCRIPTION
Add a turn-changed event so runtime systems can react to turn order updates and clear-state transitions.

Extend CurrencyBank reset to alert HUD listeners that balances were cleared and cover the changes with unit tests.

Refs #9